### PR TITLE
fix: make stress table scrollable and harden regex case sensitivity

### DIFF
--- a/lib/features/stress/presentation/widgets/stress_table.dart
+++ b/lib/features/stress/presentation/widgets/stress_table.dart
@@ -12,6 +12,7 @@ class StressTable extends StatelessWidget {
   Widget build(BuildContext context) {
     final dividerColor = Theme.of(context).dividerColor;
     return SingleChildScrollView(
+      primary: true,
       child: Table(
         columnWidths: const {
           0: FlexColumnWidth(2),

--- a/lib/features/stress/presentation/widgets/stress_table.dart
+++ b/lib/features/stress/presentation/widgets/stress_table.dart
@@ -11,46 +11,48 @@ class StressTable extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final dividerColor = Theme.of(context).dividerColor;
-    return Table(
-      columnWidths: const {
-        0: FlexColumnWidth(2),
-        1: FlexColumnWidth(3),
-      },
-      border: TableBorder(
-        bottom: BorderSide(
-          color: dividerColor,
+    return SingleChildScrollView(
+      child: Table(
+        columnWidths: const {
+          0: FlexColumnWidth(2),
+          1: FlexColumnWidth(3),
+        },
+        border: TableBorder(
+          bottom: BorderSide(
+            color: dividerColor,
+          ),
+          top: BorderSide(
+            color: dividerColor,
+          ),
+          horizontalInside: BorderSide(
+            color: dividerColor,
+          ),
+          verticalInside: BorderSide(
+            color: dividerColor,
+          ),
         ),
-        top: BorderSide(
-          color: dividerColor,
-        ),
-        horizontalInside: BorderSide(
-          color: dividerColor,
-        ),
-        verticalInside: BorderSide(
-          color: dividerColor,
-        ),
+        children: rows
+            .map(
+              (row) => TableRow(
+                children: [
+                  TableCell(
+                    verticalAlignment: TableCellVerticalAlignment.middle,
+                    child: Padding(
+                      padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+                      child: StressHtmlCell(html: row.title),
+                    ),
+                  ),
+                  TableCell(
+                    child: Padding(
+                      padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+                      child: StressHtmlCell(html: row.content),
+                    ),
+                  ),
+                ],
+              ),
+            )
+            .toList(),
       ),
-      children: rows
-          .map(
-            (row) => TableRow(
-              children: [
-                TableCell(
-                  verticalAlignment: TableCellVerticalAlignment.middle,
-                  child: Padding(
-                    padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
-                    child: StressHtmlCell(html: row.title),
-                  ),
-                ),
-                TableCell(
-                  child: Padding(
-                    padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
-                    child: StressHtmlCell(html: row.content),
-                  ),
-                ),
-              ],
-            ),
-          )
-          .toList(),
     );
   }
 }

--- a/lib/features/translation/domain/entity/translation.dart
+++ b/lib/features/translation/domain/entity/translation.dart
@@ -19,7 +19,11 @@ class Translation extends Equatable {
   };
 
   static List<String> _extractRusBelCandidates(String html) {
-    final fontPattern = RegExp(r'<font[^>]*color="#831b03"[^>]*>(.*?)</font>', dotAll: true);
+    final fontPattern = RegExp(
+      r'<font[^>]*color="#831b03"[^>]*>(.*?)</font>',
+      dotAll: true,
+      caseSensitive: false,
+    );
     final candidates = <String>{};
     for (final match in fontPattern.allMatches(html)) {
       final text = match.group(1)!.replaceAll(RegExp(r'<[^>]+>'), '').trim();

--- a/lib/features/translation/domain/entity/translation.dart
+++ b/lib/features/translation/domain/entity/translation.dart
@@ -20,7 +20,7 @@ class Translation extends Equatable {
 
   static List<String> _extractRusBelCandidates(String html) {
     final fontPattern = RegExp(
-      r'<font[^>]*color="#831b03"[^>]*>(.*?)</font>',
+      r'''<font[^>]*color=["']#831b03["'][^>]*>(.*?)</font>''',
       dotAll: true,
       caseSensitive: false,
     );


### PR DESCRIPTION
Wrap StressTable in SingleChildScrollView to prevent overflow on long declension/conjugation tables. Make font color RegExp case-insensitive to handle non-lowercase HTML from the API.