### PR TITLE
fix: anchor deep link regex and scope app link intent-filter

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -41,6 +41,11 @@
 
                 <data android:host="${appHostname}"/>
                 <data android:host="www.${appHostname}"/>
+
+                <data android:pathPrefix="/belrus/"/>
+                <data android:pathPrefix="/rusbel/"/>
+                <data android:pathPrefix="/tsbm/"/>
+                <data android:pathPrefix="/r/"/>
             </intent-filter>
         </activity>
         <!-- Не лагаваць у аналітыку пераходы па экранах -->

--- a/lib/features/app/domain/use_case/handle_app_link.dart
+++ b/lib/features/app/domain/use_case/handle_app_link.dart
@@ -17,7 +17,7 @@ class HandleAppLinkUseCase {
     try {
       _logger.fine('Уваходзячы апп лінк: $appLink');
       final regex = RegExp(
-        r'^(https?://(www\.)?(skarnik\.by|skarnik\.app))?/(r/)?(?<dictPath>belrus|rusbel|tsbm)/(?<wordId>[0-9]+)/?(\?.*)?$',
+        r'^(https?://(www\.)?(skarnik\.by|skarnik\.app))?/(r/)?(?<dictPath>belrus|rusbel|tsbm)/(?<wordId>[0-9]+)/?([?#].*)?$',
       );
       if (!regex.hasMatch(appLink)) {
         throw ArgumentError('Не атрымалася распарсіць app link');

--- a/lib/features/app/domain/use_case/handle_app_link.dart
+++ b/lib/features/app/domain/use_case/handle_app_link.dart
@@ -17,7 +17,7 @@ class HandleAppLinkUseCase {
     try {
       _logger.fine('Уваходзячы апп лінк: $appLink');
       final regex = RegExp(
-        r'^(https?://(www\.)?(skarnik\.by|skarnik\.app))?/(r/)?(?<dictPath>belrus|rusbel|tsbm)/(?<wordId>[0-9]+)$',
+        r'^(https?://(www\.)?(skarnik\.by|skarnik\.app))?/(r/)?(?<dictPath>belrus|rusbel|tsbm)/(?<wordId>[0-9]+)/?(\?.*)?$',
       );
       if (!regex.hasMatch(appLink)) {
         throw ArgumentError('Не атрымалася распарсіць app link');

--- a/lib/features/app/domain/use_case/handle_app_link.dart
+++ b/lib/features/app/domain/use_case/handle_app_link.dart
@@ -17,7 +17,7 @@ class HandleAppLinkUseCase {
     try {
       _logger.fine('Уваходзячы апп лінк: $appLink');
       final regex = RegExp(
-        r'(https?://(www\.)?(skarnik\.by|skarnik\.app))?/(r/)?(?<dictPath>belrus|rusbel|tsbm)/(?<wordId>[0-9]+)',
+        r'^(https?://(www\.)?(skarnik\.by|skarnik\.app))?/(r/)?(?<dictPath>belrus|rusbel|tsbm)/(?<wordId>[0-9]+)$',
       );
       if (!regex.hasMatch(appLink)) {
         throw ArgumentError('Не атрымалася распарсіць app link');

--- a/test/features/app/domain/use_case/handle_app_link_test.dart
+++ b/test/features/app/domain/use_case/handle_app_link_test.dart
@@ -53,6 +53,8 @@ void main() {
       'https://skarnik.by/belrus/notanumber',
       'not a link at all',
       '',
+      'https://evil.com/search?url=/belrus/$wordId',
+      'https://skarnik.by/belrus/$wordId/extra',
     ]) {
       test('returns Failure for unparsable link `$badLink`', () async {
         final result = await useCase.call(badLink);

--- a/test/features/app/domain/use_case/handle_app_link_test.dart
+++ b/test/features/app/domain/use_case/handle_app_link_test.dart
@@ -52,8 +52,10 @@ void main() {
       'https://skarnik.by/tsbm/$wordId/',
       'https://skarnik.by/tsbm/$wordId?utm_source=share',
       'https://skarnik.by/tsbm/$wordId/?utm_source=share',
+      'https://skarnik.by/tsbm/$wordId#section',
+      'https://skarnik.by/tsbm/$wordId/#section',
     ]) {
-      test('parses `$link` with trailing slash and/or query params', () async {
+      test('parses `$link` with trailing slash, query params, and/or fragment', () async {
         final result = await useCase.call(link);
 
         expect(result, isA<Success<({int langId, int wordId})>>());

--- a/test/features/app/domain/use_case/handle_app_link_test.dart
+++ b/test/features/app/domain/use_case/handle_app_link_test.dart
@@ -48,6 +48,21 @@ void main() {
       expect(pair.wordId, wordId);
     });
 
+    for (final link in [
+      'https://skarnik.by/tsbm/$wordId/',
+      'https://skarnik.by/tsbm/$wordId?utm_source=share',
+      'https://skarnik.by/tsbm/$wordId/?utm_source=share',
+    ]) {
+      test('parses `$link` with trailing slash and/or query params', () async {
+        final result = await useCase.call(link);
+
+        expect(result, isA<Success<({int langId, int wordId})>>());
+        final pair = (result as Success<({int langId, int wordId})>).result;
+        expect(pair.langId, Dictionary.tsbm.langId);
+        expect(pair.wordId, wordId);
+      });
+    }
+
     for (final badLink in [
       'https://skarnik.by/unknown/1000',
       'https://skarnik.by/belrus/notanumber',


### PR DESCRIPTION
Unanchored regex let any string containing /belrus|rusbel|tsbm/<id> match regardless of host (e.g. https://evil.com/search?url=/belrus/1). Intent-filter had no pathPrefix, so the app intercepted every URL on skarnik.by/skarnik.app, not just dictionary entries.