### PR TITLE
fix: extract belRus stress candidates from html font tags

### DIFF
--- a/lib/features/translation/domain/entity/translation.dart
+++ b/lib/features/translation/domain/entity/translation.dart
@@ -14,8 +14,8 @@ class Translation extends Equatable {
   String get maybeStressedWord => stress ?? word.word;
 
   late final List<String> stressCandidates = switch (word.dictionary) {
-    Dictionary.belRus || Dictionary.tsbm => word.word.contains(' ') ? const [] : [word.word],
-    Dictionary.rusBel => _extractRusBelCandidates(html),
+    Dictionary.tsbm => word.word.contains(' ') ? const [] : [word.word],
+    Dictionary.belRus || Dictionary.rusBel => _extractRusBelCandidates(html),
   };
 
   static List<String> _extractRusBelCandidates(String html) {

--- a/lib/features/translation/domain/entity/translation.dart
+++ b/lib/features/translation/domain/entity/translation.dart
@@ -15,10 +15,10 @@ class Translation extends Equatable {
 
   late final List<String> stressCandidates = switch (word.dictionary) {
     Dictionary.tsbm => word.word.contains(' ') ? const [] : [word.word],
-    Dictionary.belRus || Dictionary.rusBel => _extractRusBelCandidates(html),
+    Dictionary.belRus || Dictionary.rusBel => _extractCandidatesFromHtml(html),
   };
 
-  static List<String> _extractRusBelCandidates(String html) {
+  static List<String> _extractCandidatesFromHtml(String html) {
     final fontPattern = RegExp(
       r'''<font[^>]*color=["']#831b03["'][^>]*>(.*?)</font>''',
       dotAll: true,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 3.1.5+52
+version: 3.1.6+53
 
 environment:
   sdk: ^3.11.5

--- a/test/features/translation/domain/entity/translation_test.dart
+++ b/test/features/translation/domain/entity/translation_test.dart
@@ -41,14 +41,22 @@ void main() {
 
     group('stressCandidates', () {
       group('belRus', () {
-        test('single word → [word]', () {
-          final t = _translation(word: _word('слова', Dictionary.belRus));
-          expect(t.stressCandidates, ['слова']);
+        test('no matching font tags → []', () {
+          final t = _translation(word: _word('слова', Dictionary.belRus), html: '<p>слова</p>');
+          expect(t.stressCandidates, isEmpty);
         });
 
-        test('multi-word phrase → []', () {
-          final t = _translation(word: _word('добры дзень', Dictionary.belRus));
-          expect(t.stressCandidates, isEmpty);
+        test('extracts candidates from font tags (real API sample)', () {
+          final t = _translation(
+            word: _word('бурштын', Dictionary.belRus),
+            html:
+                '<span class="nrt">янтарь</span> — &nbsp;&nbsp;'
+                '<font size="+2" color="#831b03">янтар</font>, '
+                '<i>-ру <font color="#008000">муж.</font></i>, '
+                '<font size="+2" color="#831b03">бурштын</font>, '
+                '<i>-ну <font color="#008000">муж.</font></i>',
+          );
+          expect(t.stressCandidates, ['бурштын', 'янтар']);
         });
       });
 
@@ -108,7 +116,8 @@ void main() {
         test('deduplicates repeated words', () {
           final t = _translation(
             word: _word('интересный', Dictionary.rusBel),
-            html: '<font size="+2" color="#831b03">цікавы</font>'
+            html:
+                '<font size="+2" color="#831b03">цікавы</font>'
                 '<font size="+2" color="#831b03">цікавы</font>',
           );
           expect(t.stressCandidates, ['цікавы']);


### PR DESCRIPTION
belRus API responses carry the same #831b03 font markup as rusBel (verified against live data for /belrus/15519), so belRus should use the same html-based extraction instead of falling back to the bare word. Updates the belRus test cases to match.