### PR TITLE
refactor(settings): improve About sheet M3 compliance and add leading…

### DIFF
--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -45,8 +45,7 @@ platform :android do
                "appbundle",
                "--release",
                "-t", "lib/main.dart",
-               "--dart-define=API_HOSTNAME=#{ENV['API_HOSTNAME']}",
-               "--dart-define=DEV_EMAIL_ADDRESS=#{ENV['DEV_EMAIL_ADDRESS']}",
+               "--dart-define-from-file=android/fastlane/.env.secret",
              ]
            )
   end
@@ -58,8 +57,7 @@ platform :android do
                "build",
                "apk",
                "--release",
-               "--dart-define=API_HOSTNAME=#{ENV['API_HOSTNAME']}",
-               "--dart-define=DEV_EMAIL_ADDRESS=#{ENV['DEV_EMAIL_ADDRESS']}",
+               "--dart-define-from-file=android/fastlane/.env.secret",
              ]
            )
   end

--- a/lib/app_config.dart
+++ b/lib/app_config.dart
@@ -20,6 +20,8 @@ abstract class AppConfig {
 
   static const starnikSiteHostName = 'starnik.by';
 
+  static const drukarnikSiteHostName = 'drukarnik.app';
+
   static const skarnikAppSiteHostName = 'skarnik.app';
 
   static const apiHostName = String.fromEnvironment('API_HOSTNAME');

--- a/lib/features/settings/presentation/settings_page.dart
+++ b/lib/features/settings/presentation/settings_page.dart
@@ -51,7 +51,6 @@ class SettingsPage extends StatelessWidget {
                       );
                     },
                   ),
-                  const Divider(),
                   ListTile(
                     leading: const Icon(Icons.email_outlined),
                     title: const Text(Strings.writeToDevs),
@@ -65,7 +64,6 @@ class SettingsPage extends StatelessWidget {
                       useSafeArea: true,
                       showDragHandle: true,
                       isScrollControlled: true,
-                      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
                       builder: (context) => BlocProvider.value(
                         value: cubit,
                         child: const AboutBottomSheet(),

--- a/lib/features/settings/presentation/settings_page.dart
+++ b/lib/features/settings/presentation/settings_page.dart
@@ -44,6 +44,7 @@ class SettingsPage extends StatelessWidget {
                     builder: (context, state) {
                       final enabled = state is! SettingsInProgressState;
                       return ListTile(
+                        leading: const Icon(Icons.auto_delete_rounded),
                         title: const Text(Strings.clearHistory),
                         onTap: () => _showClearHistoryConfirmation(context),
                         enabled: enabled,
@@ -52,10 +53,12 @@ class SettingsPage extends StatelessWidget {
                   ),
                   const Divider(),
                   ListTile(
+                    leading: const Icon(Icons.email_rounded),
                     title: const Text(Strings.writeToDevs),
                     onTap: cubit.mailToDevs,
                   ),
                   ListTile(
+                    leading: const Icon(Icons.info_rounded),
                     title: const Text(Strings.aboutSkarnik),
                     onTap: () => showModalBottomSheet(
                       context: context,
@@ -68,20 +71,6 @@ class SettingsPage extends StatelessWidget {
                         child: const AboutBottomSheet(),
                       ),
                     ),
-                  ),
-                  FutureBuilder<String>(
-                    future: cubit.getAppNameAndVersion(),
-                    builder: (context, snapshot) {
-                      if (snapshot.hasData) {
-                        final data = snapshot.data;
-                        if (data != null) {
-                          return ListTile(
-                            subtitle: Text(data),
-                          );
-                        }
-                      }
-                      return const SizedBox.shrink();
-                    },
                   ),
                 ],
               );

--- a/lib/features/settings/presentation/settings_page.dart
+++ b/lib/features/settings/presentation/settings_page.dart
@@ -44,7 +44,7 @@ class SettingsPage extends StatelessWidget {
                     builder: (context, state) {
                       final enabled = state is! SettingsInProgressState;
                       return ListTile(
-                        leading: const Icon(Icons.auto_delete_rounded),
+                        leading: const Icon(Icons.auto_delete_outlined),
                         title: const Text(Strings.clearHistory),
                         onTap: () => _showClearHistoryConfirmation(context),
                         enabled: enabled,
@@ -53,12 +53,12 @@ class SettingsPage extends StatelessWidget {
                   ),
                   const Divider(),
                   ListTile(
-                    leading: const Icon(Icons.email_rounded),
+                    leading: const Icon(Icons.email_outlined),
                     title: const Text(Strings.writeToDevs),
                     onTap: cubit.mailToDevs,
                   ),
                   ListTile(
-                    leading: const Icon(Icons.info_rounded),
+                    leading: const Icon(Icons.info_outline),
                     title: const Text(Strings.aboutSkarnik),
                     onTap: () => showModalBottomSheet(
                       context: context,

--- a/lib/features/settings/presentation/widgets/about_bottom_sheet.dart
+++ b/lib/features/settings/presentation/widgets/about_bottom_sheet.dart
@@ -3,13 +3,38 @@ import 'dart:io';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:skarnik_flutter/app_config.dart';
 import 'package:skarnik_flutter/strings.dart';
-import 'package:url_launcher/url_launcher_string.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import '../settings_cubit.dart';
 
-class AboutBottomSheet extends StatelessWidget {
+class AboutBottomSheet extends StatefulWidget {
   const AboutBottomSheet({super.key});
+
+  @override
+  State<AboutBottomSheet> createState() => _AboutBottomSheetState();
+}
+
+class _AboutBottomSheetState extends State<AboutBottomSheet> {
+  final TapGestureRecognizer _skarnikLinkRecognizer = TapGestureRecognizer()
+    ..onTap = () => launchUrl(
+      Uri(scheme: 'https', host: AppConfig.skarnikSiteHostName),
+      mode: LaunchMode.externalApplication,
+    );
+  late final Future<String> _appNameAndVersion;
+
+  @override
+  void initState() {
+    super.initState();
+    _appNameAndVersion = context.read<SettingsCubit>().getAppNameAndVersion();
+  }
+
+  @override
+  void dispose() {
+    _skarnikLinkRecognizer.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -37,17 +62,13 @@ class AboutBottomSheet extends StatelessWidget {
                             'Гэтая праграма — ${Platform.isIOS ? 'iOS' : 'Android'}-кліент сайта ',
                       ),
                       TextSpan(
-                        text: 'Skarnik.by',
+                        text: AppConfig.skarnikSiteHostName,
                         style: TextStyle(
                           decoration: TextDecoration.underline,
                           color: Theme.of(context).colorScheme.primary,
                           decorationColor: Theme.of(context).colorScheme.primary,
                         ),
-                        recognizer: TapGestureRecognizer()
-                          ..onTap = () => launchUrlString(
-                            'https://skarnik.by',
-                            mode: LaunchMode.externalApplication,
-                          ),
+                        recognizer: _skarnikLinkRecognizer,
                       ),
                       const TextSpan(
                         text: '. Працуе ў рэжыме анлайн.',
@@ -125,14 +146,14 @@ class AboutBottomSheet extends StatelessWidget {
               color: Theme.of(context).colorScheme.primary,
             ),
             title: const Text(
-              'Starnik.by',
+              AppConfig.starnikSiteHostName,
               style: TextStyle(
                 decoration: TextDecoration.underline,
               ),
             ),
             subtitle: const Text(Strings.aboutStarnikByDescription),
-            onTap: () => launchUrlString(
-              'https://starnik.by',
+            onTap: () => launchUrl(
+              Uri(scheme: 'https', host: AppConfig.starnikSiteHostName),
               mode: LaunchMode.externalApplication,
             ),
           ),
@@ -142,27 +163,27 @@ class AboutBottomSheet extends StatelessWidget {
               color: Theme.of(context).colorScheme.primary,
             ),
             title: const Text(
-              'Drukarnik.app',
+              AppConfig.drukarnikSiteHostName,
               style: TextStyle(
                 decoration: TextDecoration.underline,
               ),
             ),
             subtitle: const Text(Strings.aboutDrukarnikDescription),
-            onTap: () => launchUrlString(
-              'https://drukarnik.app',
+            onTap: () => launchUrl(
+              Uri(scheme: 'https', host: AppConfig.drukarnikSiteHostName),
               mode: LaunchMode.externalApplication,
             ),
           ),
           Padding(
             padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
             child: TextButton.icon(
-              icon: const Icon(Icons.email_rounded),
+              icon: const Icon(Icons.email_outlined),
               onPressed: context.read<SettingsCubit>().mailToDevs,
               label: const Text(Strings.writeToDevs),
             ),
           ),
           FutureBuilder<String>(
-            future: context.read<SettingsCubit>().getAppNameAndVersion(),
+            future: _appNameAndVersion,
             builder: (context, snapshot) {
               if (snapshot.hasData) {
                 final data = snapshot.data;

--- a/lib/features/settings/presentation/widgets/about_bottom_sheet.dart
+++ b/lib/features/settings/presentation/widgets/about_bottom_sheet.dart
@@ -13,100 +13,173 @@ class AboutBottomSheet extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: Padding(
-        padding: const EdgeInsets.all(16),
-        child: RichText(
-          text: TextSpan(
-            style: Theme.of(context).textTheme.bodyMedium,
-            children: [
-              TextSpan(
+    return SafeArea(
+      bottom: true,
+      child: ListView(
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 0),
+            child: Text(
+              Strings.aboutSkarnik,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+            child: RichText(
+              text: TextSpan(
+                style: Theme.of(context).textTheme.bodyMedium,
                 children: [
                   TextSpan(
-                    text: 'Гэтая праграма — ${Platform.isIOS ? 'iOS' : 'Android'}-кліент сайта ',
-                  ),
-                  TextSpan(
-                    text: 'Skarnik.by',
-                    style: TextStyle(
-                      decoration: TextDecoration.underline,
-                      color: Theme.of(context).colorScheme.primary,
-                      decorationColor: Theme.of(context).colorScheme.primary,
-                    ),
-                    recognizer: TapGestureRecognizer()..onTap = () => launchUrlString('https://skarnik.by'),
+                    children: [
+                      TextSpan(
+                        text:
+                            'Гэтая праграма — ${Platform.isIOS ? 'iOS' : 'Android'}-кліент сайта ',
+                      ),
+                      TextSpan(
+                        text: 'Skarnik.by',
+                        style: TextStyle(
+                          decoration: TextDecoration.underline,
+                          color: Theme.of(context).colorScheme.primary,
+                          decorationColor: Theme.of(context).colorScheme.primary,
+                        ),
+                        recognizer: TapGestureRecognizer()
+                          ..onTap = () => launchUrlString(
+                            'https://skarnik.by',
+                            mode: LaunchMode.externalApplication,
+                          ),
+                      ),
+                      const TextSpan(
+                        text: '. Працуе ў рэжыме анлайн.',
+                      ),
+                    ],
                   ),
                   const TextSpan(
-                    text: '. Працуе ў рэжыме анлайн.',
+                    children: [
+                      TextSpan(
+                        text: '\n\n1. ',
+                      ),
+                      TextSpan(
+                        text: 'Тлумачальны',
+                        style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      TextSpan(
+                        text:
+                            ' слоўнік беларускай мовы змяшчае больш за 95 тысяч слоў. Створаны на аснове акадэмічнага выдання пад рэдакцыяй К. Крапівы — пяцітомніка 1977-1984 гг.',
+                      ),
+                    ],
+                  ),
+                  const TextSpan(
+                    children: [
+                      TextSpan(
+                        text: '\n2. ',
+                      ),
+                      TextSpan(
+                        text: 'Беларуска-рускі',
+                        style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      TextSpan(
+                        text:
+                            ' слоўнік змяшчае больш за 100 тысяч слоў. Гэта «адваротны» слоўнік ад руска-беларускага.',
+                      ),
+                    ],
+                  ),
+                  const TextSpan(
+                    children: [
+                      TextSpan(
+                        text: '\n3. ',
+                      ),
+                      TextSpan(
+                        text: 'Руска-беларускі',
+                        style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      TextSpan(
+                        text:
+                            ' слоўнік таксама змяшчае больш за 100 тысяч слоў. За аснову ўзяты акадэмічны слоўнік пад рэдакцыяй Я. Коласа, К. Крапівы і П. Глебкі.',
+                      ),
+                    ],
+                  ),
+                  const TextSpan(
+                    text: '\n\nСайт skarnik.by пачаў працаваць 7 жніўня 2012 года.',
                   ),
                 ],
               ),
-              const TextSpan(
-                children: [
-                  TextSpan(
-                    text: '\n\n\t\t\t1. ',
-                  ),
-                  TextSpan(
-                    text: 'Тлумачальны',
-                    style: TextStyle(
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                  TextSpan(
-                    text:
-                        ' слоўнік беларускай мовы змяшчае больш за 95 тысяч слоў. Створаны на аснове акадэмічнага выдання пад рэдакцыяй К. Крапівы — пяцітомніка 1977-1984 гг.',
-                  ),
-                ],
-              ),
-              const TextSpan(
-                children: [
-                  TextSpan(
-                    text: '\n\t\t\t2. ',
-                  ),
-                  TextSpan(
-                    text: 'Беларуска-рускі',
-                    style: TextStyle(
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                  TextSpan(
-                    text: ' слоўнік змяшчае больш за 100 тысяч слоў. Гэта «адваротны» слоўнік ад руска-беларускага.',
-                  ),
-                ],
-              ),
-              const TextSpan(
-                children: [
-                  TextSpan(
-                    text: '\n\t\t\t3. ',
-                  ),
-                  TextSpan(
-                    text: 'Руска-беларускі',
-                    style: TextStyle(
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                  TextSpan(
-                    text:
-                        ' слоўнік таксама змяшчае больш за 100 тысяч слоў. За аснову ўзяты акадэмічны слоўнік пад рэдакцыяй Я. Коласа, К. Крапівы і П. Глебкі.',
-                  ),
-                ],
-              ),
-              const TextSpan(
-                text:
-                    '\n\n\t\t\tСкарнік дапрацаваны з улікам сучаснай практыкі і ўвесь час абнаўляецца (дадаюцца новыя словы, выпраўляюцца памылкі, недакладнасці і г. д.). Дзякуем усім за водгукі і прапановы.',
-              ),
-              WidgetSpan(
-                child: Center(
-                  child: Padding(
-                    padding: const EdgeInsets.fromLTRB(0, 16, 0, 16),
-                    child: TextButton(
-                      onPressed: context.read<SettingsCubit>().mailToDevs,
-                      child: const Text(Strings.writeToDevs),
-                    ),
-                  ),
-                ),
-              ),
-            ],
+            ),
           ),
-        ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+            child: Text(
+              Strings.aboutUsefulLinks,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+          ),
+          ListTile(
+            leading: const Icon(Icons.link_rounded),
+            titleTextStyle: TextStyle(
+              color: Theme.of(context).colorScheme.primary,
+            ),
+            title: const Text(
+              'Starnik.by',
+              style: TextStyle(
+                decoration: TextDecoration.underline,
+              ),
+            ),
+            subtitle: const Text(Strings.aboutStarnikByDescription),
+            onTap: () => launchUrlString(
+              'https://starnik.by',
+              mode: LaunchMode.externalApplication,
+            ),
+          ),
+          ListTile(
+            leading: const Icon(Icons.link_rounded),
+            titleTextStyle: TextStyle(
+              color: Theme.of(context).colorScheme.primary,
+            ),
+            title: const Text(
+              'Drukarnik.app',
+              style: TextStyle(
+                decoration: TextDecoration.underline,
+              ),
+            ),
+            subtitle: const Text(Strings.aboutDrukarnikDescription),
+            onTap: () => launchUrlString(
+              'https://drukarnik.app',
+              mode: LaunchMode.externalApplication,
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+            child: TextButton.icon(
+              icon: const Icon(Icons.email_rounded),
+              onPressed: context.read<SettingsCubit>().mailToDevs,
+              label: const Text(Strings.writeToDevs),
+            ),
+          ),
+          FutureBuilder<String>(
+            future: context.read<SettingsCubit>().getAppNameAndVersion(),
+            builder: (context, snapshot) {
+              if (snapshot.hasData) {
+                final data = snapshot.data;
+                if (data != null) {
+                  return ListTile(
+                    subtitle: Text(
+                      data,
+                      textAlign: TextAlign.center,
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                  );
+                }
+              }
+              return const SizedBox.shrink();
+            },
+          ),
+        ],
       ),
     );
   }

--- a/lib/features/settings/presentation/widgets/about_bottom_sheet.dart
+++ b/lib/features/settings/presentation/widgets/about_bottom_sheet.dart
@@ -141,7 +141,7 @@ class _AboutBottomSheetState extends State<AboutBottomSheet> {
             ),
           ),
           ListTile(
-            leading: const Icon(Icons.link_rounded),
+            leading: const Icon(Icons.link_outlined),
             titleTextStyle: TextStyle(
               color: Theme.of(context).colorScheme.primary,
             ),
@@ -158,7 +158,7 @@ class _AboutBottomSheetState extends State<AboutBottomSheet> {
             ),
           ),
           ListTile(
-            leading: const Icon(Icons.link_rounded),
+            leading: const Icon(Icons.link_outlined),
             titleTextStyle: TextStyle(
               color: Theme.of(context).colorScheme.primary,
             ),

--- a/lib/strings.dart
+++ b/lib/strings.dart
@@ -41,4 +41,9 @@ abstract interface class Strings {
   static const sorryTranslationError = 'Прабачце, адбылася памылка перакладу слова.';
   static const writeToDevs = 'Напісаць распрацоўшчыкам';
   static const yes = 'Так';
+  static const aboutUsefulLinks = 'Карысныя спасылкі';
+  static const aboutStarnikByDescription =
+      'Спецпошук — спецыяльны пошук па базе слоў. Адваротны слоўнік беларускай мовы — падабраць рыфму або скласці крыжаванку.';
+  static const aboutDrukarnikDescription =
+      'Друкарнік — праверка арфаграфіі, хуткія падказкі, моўны бот, прыгожая беларуская мова і добры настрой.';
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 3.1.10+57
+version: 3.1.11+58
 
 environment:
   sdk: ^3.11.5

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 3.1.11+58
+version: 3.1.12+59
 
 environment:
   sdk: ^3.11.5


### PR DESCRIPTION
… icons

Drop nested Scaffold inside modal bottom sheet (conflicted with the caller's own SafeArea/background), align link colors/icons across ListTiles, move app version display out of the settings list into the About sheet, and add useful-links descriptions.